### PR TITLE
Use a version of TorBrowser that still exists

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -4,10 +4,10 @@
 #
 #   include tor
 class tor (
-  $version = '3.6.6'
+  $version = '4.0.1'
 ) {
   package { 'TorBrowser':
     provider => 'appdmg',
-    source   => "https://www.torproject.org/dist/torbrowser/${version}/TorBrowser-${version}-osx32_en-US.dmg"
+    source   => "https://dist.torproject.org/torbrowser/${version}/TorBrowser-${version}-osx32_en-US.dmg"
   }
 }

--- a/spec/classes/tor_spec.rb
+++ b/spec/classes/tor_spec.rb
@@ -4,7 +4,7 @@ describe 'tor' do
   it do
     should contain_class('tor')
     should contain_package('TorBrowser').with({
-      :source   => 'https://www.torproject.org/dist/torbrowser/3.6.6/TorBrowser-3.6.6-osx32_en-US.dmg',
+      :source   => 'https://dist.torproject.org/torbrowser/4.0.1/TorBrowser-4.0.1-osx32_en-US.dmg',
       :provider => 'appdmg'
     })
   end


### PR DESCRIPTION
The previously set default version of TorBrowser no longer exists.
